### PR TITLE
A different approach to multi-threaded TwitIE

### DIFF
--- a/src/main/java/com/afp/medialab/weverify/social/util/AlwaysBlockingSynchronousQueue.java
+++ b/src/main/java/com/afp/medialab/weverify/social/util/AlwaysBlockingSynchronousQueue.java
@@ -1,0 +1,26 @@
+package com.afp.medialab.weverify.social.util;
+
+import java.util.concurrent.SynchronousQueue;
+
+/**
+ * A SynchronousQueue in which offer delegates to put. ThreadPoolExecutor uses
+ * offer to run a new task. Using put instead means that when all the threads
+ * in the pool are occupied, execute will wait for one of them to become free,
+ * rather than failing to submit the task.
+ */
+public class AlwaysBlockingSynchronousQueue
+        extends
+        SynchronousQueue<Runnable> {
+  /**
+   * Yes, I know this technically breaks the contract of BlockingQueue, but it
+   * works for this case.
+   */
+  public boolean offer(Runnable task) {
+    try {
+      put(task);
+    } catch(InterruptedException e) {
+      return false;
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
This is an attempt to do the multi-threaded TwitIE processing in a way that avoids fetching tweets from Elastic faster than TwitIE can process them.  This should smooth out the scroll fetches from Elastic and avoid the long delays that were causing it to lose the scroll cursor.

This borrows the AlwaysBlockingSynchronousQueue trick from GATE GCP, which is a way to make ThreadPoolExecutor.execute block its caller instead of failing when all the processing threads are occupied.